### PR TITLE
refac(clock/timer): lifted clock state to timer

### DIFF
--- a/src/components/clock/clock.js
+++ b/src/components/clock/clock.js
@@ -1,63 +1,21 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { parseTime } from '../../helpers';
 import './clock.scss';
 
-class Clock extends Component {
-    state = {
-        timerActive: false,
-        startTime: 0,
-        currentTime: 0,
-        pauseTime: 0,
-    }
-
-    interval = null;
-
-    beginTimer() {
-        const startDate = this.state.pauseTime === 0 ? Date.now() : Date.now() - this.state.pauseTime;
-        this.interval = setInterval(() => {
-            this.setState({
-                timerActive: true,
-                startTime: startDate,
-                currentTime: Date.now() - startDate,
-            });
-        }, 100)
-    }
-
-    endTimer() {
-        if (this.interval) {
-            clearInterval(this.interval);
-        }
-        this.setState({ pauseTime: Date.now() - this.state.startTime, timerActive: false });
-    }
-
-    resetTimer() {
-        this.setState({ 
-            timerActive: false,
-            startTime: 0,
-            currentTime: 0,
-            pauseTime: 0,
-        })
-    }
-
-    getTime() {
-        return this.state.currentTime;
-    }
-
-    render() {
-        return (
+const Clock = (props) => {
+    return (
+        <div>
+            <h3>Clock</h3>
             <div>
-                <h3>Clock</h3>
-                <div>
-                    <p className="time">{parseTime(this.state.currentTime)}</p>
-                </div>
-                <div className="button-row">
-                    <button disabled={this.state.timerActive} onClick={() => this.beginTimer()}>{this.state.pauseTime ? 'Resume' : 'Start'}</button>
-                    <button onClick={() => this.endTimer()}>Stop</button>
-                    <button onClick={() => this.resetTimer()}>Reset</button>
-                </div>
+                <p className="time">{parseTime(props.currentTime)}</p>
             </div>
-        );
-    }
+            <div className="button-row">
+                <button disabled={props.active} onClick={() => props.begin()}>{props.pauseTime ? 'Resume' : 'Start'}</button>
+                <button onClick={() => props.stop()}>Stop</button>
+                <button onClick={() => props.reset()}>Reset</button>
+            </div>
+        </div>
+    );
 }
 
 export default Clock;

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -5,6 +5,40 @@ import './timer.scss';
 // expects prop of flagObj
 
 class TimerComponent extends Component {
+    state = {
+        timerActive: false,
+        startTime: 0,
+        currentTime: 0,
+        pauseTime: 0,
+    }
+
+    beginTimer() {
+        const startDate = this.state.pauseTime === 0 ? Date.now() : Date.now() - this.state.pauseTime;
+        this.interval = setInterval(() => {
+            this.setState({
+                timerActive: true,
+                startTime: startDate,
+                currentTime: Date.now() - startDate,
+            });
+        }, 100)
+    }
+
+    endTimer() {
+        if (this.interval) {
+            clearInterval(this.interval);
+        }
+        this.setState({ pauseTime: Date.now() - this.state.startTime, timerActive: false });
+    }
+
+    resetTimer() {
+        this.setState({ 
+            timerActive: false,
+            startTime: 0,
+            currentTime: 0,
+            pauseTime: 0,
+        })
+    }
+
     render() {
         return (
             <div>
@@ -21,7 +55,14 @@ class TimerComponent extends Component {
                     })}
                 </div>
                 <React.Fragment>
-                    <Clock />
+                    <Clock
+                        begin={() => this.beginTimer()}
+                        stop={() => this.endTimer()}
+                        reset={() => this.resetTimer()}
+                        currentTime={this.state.currentTime}
+                        active={this.state.timerActive}
+                        pauseTime={this.state.pauseTime}
+                    />
                 </React.Fragment>
             </div>
         );


### PR DESCRIPTION
Moved the state that keep track of current time from `Clock` to its parent `Timer`. This accomplishes two things: 
- Clock component is now fully functional with its only concern being display
- Now the Timer component (while also being more aptly named) can pass the current time to objectives. When an objective finishes, it can execute a call back listing the id and time, the Timer component can alter the `flagObj` and the respective Objective should re-render with a finished time. 