### PR TITLE
Milon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4-timer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "dependencies": {
     "node-sass": "^4.13.0",

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>FE v4 Objective Timer</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.scss
+++ b/src/App.scss
@@ -8,3 +8,7 @@ body {
 #root {
   width: 100%;
 }
+
+.text-center {
+  text-align: center;
+}

--- a/src/components/clock/clock.js
+++ b/src/components/clock/clock.js
@@ -12,8 +12,9 @@ const Clock = (props) => {
                     <button onClick={() => props.stop()}>Stop</button>
                     <button onClick={() => props.reset()}>Reset</button>
                 </div>
-                <div className="time-button-container">
+                <div className="time-button-container time-bottom">
                     <button className="re-entry-button" onClick={() => props.reEntry()}>Re-Enter Flag String</button>
+                    <p>Returning to the flag-input screen will end the run in progress...</p>
                 </div>
             </div>
             

--- a/src/components/clock/clock.scss
+++ b/src/components/clock/clock.scss
@@ -37,3 +37,11 @@
     }
 }
 
+.time-bottom {
+    flex-direction: column;
+    p {
+        color: #fadf0f;
+        font-size: 14px;
+    }
+}
+

--- a/src/components/clock/clock.scss
+++ b/src/components/clock/clock.scss
@@ -45,3 +45,6 @@
     }
 }
 
+.hidden {
+    visibility: hidden;
+}

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -4,9 +4,12 @@ import './flag-input.scss';
 
 const FlagInputComponent = (props) => {
     return (
-        <div className="flag-input-container">
-            <FlagInputForm startTime={(flagObj) => props.onStartTimer(flagObj)}/>
-        </div>
+        <React.Fragment>
+            <div className="flag-input-container">
+                <FlagInputForm startTime={(flagObj) => props.onStartTimer(flagObj)}/>
+            </div>
+            <p className="credits">v0.2.1 - Timer made by Fleury14</p>
+        </React.Fragment>
     );
 }
 

--- a/src/components/flag-input/flag-input.scss
+++ b/src/components/flag-input/flag-input.scss
@@ -22,8 +22,13 @@ form.flag-input-form button {
     color: #fff;
     height: 30px;
     width: 200px;
-    margin: 20px auto;
+    margin: 20px auto 5px;
     font-size: 14px;
     border-radius: 5px;
     border: none;
+}
+
+.credits {
+    font-size: 10px;
+    text-align: center;
 }

--- a/src/components/main/main.js
+++ b/src/components/main/main.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { FlagInput, Timer } from '..';
 import './main.scss';
-import { tryStatement } from '@babel/types';
 
 class MainComponent extends Component {
     state = {

--- a/src/components/main/main.js
+++ b/src/components/main/main.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { FlagInput, Timer } from '..';
 import './main.scss';
+import { tryStatement } from '@babel/types';
 
 class MainComponent extends Component {
     state = {

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -69,11 +69,13 @@ class TimerComponent extends Component {
         if (this.state.flagObj) {
             sortedObj = this.state.flagObj.objectives.sort((a, b) => a.time - b.time);
         }
+        const hasFinishedOne = (this.state.flagObj && this.state.flagObj.objectives && this.state.flagObj.objectives.find(obj => obj.time !== 0));
         
         return (
             <div>
                 <div>
                     <h2>Objectives Remaining</h2>
+                    {/* this handles pre-start display, and avoids the need to set state upon mounting/updating */}
                     {!this.state.timerActive && this.props.flagObj && this.props.flagObj.objectives.map(objective => {
                         if (!objective.time) return (
                             <Objective
@@ -86,6 +88,7 @@ class TimerComponent extends Component {
                         )
                         return null;
                     })}
+                    {/* incomplete objective display upon starting the timer */}
                     {this.state.timerActive && this.state.flagObj && this.state.flagObj.objectives.map(objective => {
                         if (!objective.time) return (
                             <Objective
@@ -99,7 +102,8 @@ class TimerComponent extends Component {
                         )
                         return null;
                     })}
-                    <h2>Objectives Complete</h2>
+                    {/* completed objectives */}
+                    <h2 className={hasFinishedOne ? '' : 'hidden'}>Objectives Complete</h2>
                     {sortedObj && sortedObj.map(objective => {
                         if (objective.time) return (
                             <Objective

--- a/src/helpers/parse-flags.js
+++ b/src/helpers/parse-flags.js
@@ -60,7 +60,7 @@ const parseFlags = (flagString) => {
 
     // custom - boss hunt
 
-    const bosses = ['dmist', 'officer', 'octomamm', 'antlion', 'waterhag', 'mombomb', 'fabulgauntlet', 'milon', 'milonz', 'mirrorcecil',
+    const bosses = ['dmist', 'officer', 'octomamm', 'antlion', 'waterhag', 'mombomb', 'fabulgauntlet', 'milonz', 'mirrorcecil',
         'guard', 'karate', 'baigan', 'kainazzo', 'darkelf', 'magus', 'valvalis', 'calbrena', 'golbez', 'lugae', 'darkimp', 'kingqueen',
         'rubicant', 'evilwall', 'asura', 'leviatan', 'odin', 'bahamut', 'elements', 'cpu', 'paledim', 'wyvern', 'plague', 'dlunar', 'ogopogo'];
     
@@ -72,6 +72,13 @@ const parseFlags = (flagString) => {
                 time: 0,
             });
         }
+    }
+
+    if (flagString.indexOf('boss_milon') >= 0 && flagString.indexOf('boss_milonz' < 0)) {
+        flagObj.objectives.push({
+            id: flagObj.objectives.length,
+            label: 'Defeat Milon'
+        });
     }
 
     // custom quests

--- a/src/helpers/parse-flags.js
+++ b/src/helpers/parse-flags.js
@@ -74,7 +74,8 @@ const parseFlags = (flagString) => {
         }
     }
 
-    if (flagString.indexOf('boss_milon') >= 0 && flagString.indexOf('boss_milonz' < 0)) {
+    // Milon needs a special exemption since you cant spell 'milonz' without 'milon'
+    if (flagString.indexOf('boss_milon/') >= 0 || flagString.indexOf('boss_milon ') >= 0) {
         flagObj.objectives.push({
             id: flagObj.objectives.length,
             label: 'Defeat Milon'


### PR DESCRIPTION
- Fixed issue found by penguin8r where having `milonz` as a boss objective in the flags was parsed as both Milon and Milon-Z.
- Added credits with version number.
- Added a warning underneath the re-entry button, since clicking on the button will effectively reset the run.
- "Objectives Complete" label is now hidden (but not removed) until an objective is actually finished.
- Added an actual title