### PR TITLE
Boss timer move

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4-timer",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "dependencies": {
     "firebase": "^7.3.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -18,3 +18,7 @@ body {
   justify-content: center;
   align-items: center;
 }
+
+.no-scroll {
+  overflow: hidden;
+}

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -42,8 +42,12 @@ class BossTimer extends Component<Props, State> {
                 this.endTimer();
             } else {
                 // user did not select a boss to assign this to, allow it to be unassigned
+                if (document.body) document.body.classList.add('no-scroll');
                 this.props.assignBoss({ id: 99, title: '???', time: this.state.currentTime });
-                this.setState({ isActive: false, finished: true });
+                
+                this.setState({ isActive: false, finished: true }, () => {
+                    if(document.body) document.body.classList.remove('no-scroll')
+                });
                 this.resetTimer();
             }
         }
@@ -108,12 +112,19 @@ class BossTimer extends Component<Props, State> {
                             if (this.interval) {
                                 clearInterval(this.interval);
                             }
+                            console.log(document.body);
+                            if (document.body !== null) document.body.classList.add('no-scroll');
+                            
+                            
                             this.setState({
                                 isActive: false,
                                 startTime: 0,
                                 currentTime: 0,
                                 pauseTime: 0,
                                 finished: true,
+                            }, () => {
+                                if (document.body) document.body.classList.remove('no-scroll');
+                                
                             });
                         }}
                     />

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -112,8 +112,7 @@ class BossTimer extends Component<Props, State> {
                             if (this.interval) {
                                 clearInterval(this.interval);
                             }
-                            console.log(document.body);
-                            if (document.body !== null) document.body.classList.add('no-scroll');
+                            if (document.body) document.body.classList.add('no-scroll');
                             
                             
                             this.setState({

--- a/src/components/clock/clock.js
+++ b/src/components/clock/clock.js
@@ -14,6 +14,7 @@ type Props = {
     reset: Function,
     reEntry: Function,
     bossTimer?: boolean,
+    children: any,
 }
 
 const Clock = (props: Props) => {
@@ -22,6 +23,9 @@ const Clock = (props: Props) => {
         <div>
             <div className={`${bossTimer ? 'boss-' : ''}time-container`}>
                 <p className={`time${props.finished ? ' time-finished' : ''}${bossTimer ? 'boss-time' : ''}`}>{parseTime(props.currentTime)}</p>
+                <div>
+                    {props.children}
+                </div>
                 <div className={`${bossTimer ? 'boss-' : ''}time-button-container`}>
                     <button disabled={props.active || (props.bossTimer && !props.pauseTime)} onClick={() => props.begin()}>{props.pauseTime ? 'Resume' : 'Start'}</button>
                     <button onClick={() => props.stop()}>Stop</button>

--- a/src/components/clock/clock.scss
+++ b/src/components/clock/clock.scss
@@ -1,6 +1,9 @@
 .time {
     font-size: 60px;
+    line-height: 80px;
+    width: 200px;
     margin: 0;
+    margin-left: 100px;
 }
 
 .time-finished {
@@ -8,8 +11,7 @@
 }
 
 .time-container {
-    width: 200px;
-    margin: 0 auto;
+    width: 400px;
 }
 
 .boss-time-container {
@@ -36,11 +38,11 @@
 
 .time-button-container {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-around;
     margin: 50px auto 10px;
 
     button {
-        width: 60px;
+        width: 80px;
         height: 40px;
         background-color: #262626;
         color: #ff9c33;

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -196,7 +196,6 @@ class TimerComponent extends Component<Props, State> {
                             pauseTime={this.state.pauseTime}
                             finished={this.state.finished}
                             reEntry={() => this.props.reEntry()}
-                            assignBoss={({ id, title, time }) => this.setState({ bossTimes: [...this.state.bossTimes, { id, title, time }]})}
                         >
                             <BossTimer 
                                 assignBoss={({ id, title, time }) => this.setState({ bossTimes: [...this.state.bossTimes, { id, title, time }]})}

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -187,27 +187,6 @@ class TimerComponent extends Component<Props, State> {
                         })}
                     </div>
                     <React.Fragment>
-                        <BossTimer 
-                            assignBoss={({ id, title, time }) => this.setState({ bossTimes: [...this.state.bossTimes, { id, title, time }]})}
-                        />
-                    </React.Fragment>
-                    {this.state.bossTimes.length ? (
-                        <BossDisplayTime
-                            modifyTime={({ id, title, time }) => {
-                                const currentTimes = this.state.bossTimes.slice();
-                                if (currentTimes) {
-                                    const foundTime = currentTimes.find(eachTime => eachTime.time === time);
-                                    if (foundTime) {
-                                        foundTime.id = id;
-                                        foundTime.title = title;
-                                        this.setState({ bossTimes: currentTimes });
-                                    }
-                                }
-                            }}
-                            bossTimes={this.state.bossTimes}
-                        />
-                    ) : null}
-                    <React.Fragment>
                         <Clock
                             begin={() => this.beginTimer()}
                             stop={() => this.endTimer()}
@@ -217,7 +196,28 @@ class TimerComponent extends Component<Props, State> {
                             pauseTime={this.state.pauseTime}
                             finished={this.state.finished}
                             reEntry={() => this.props.reEntry()}
-                        />
+                            assignBoss={({ id, title, time }) => this.setState({ bossTimes: [...this.state.bossTimes, { id, title, time }]})}
+                        >
+                            <BossTimer 
+                                assignBoss={({ id, title, time }) => this.setState({ bossTimes: [...this.state.bossTimes, { id, title, time }]})}
+                            />
+                            {this.state.bossTimes.length ? (
+                            <BossDisplayTime
+                                modifyTime={({ id, title, time }) => {
+                                    const currentTimes = this.state.bossTimes.slice();
+                                    if (currentTimes) {
+                                        const foundTime = currentTimes.find(eachTime => eachTime.time === time);
+                                        if (foundTime) {
+                                            foundTime.id = id;
+                                            foundTime.title = title;
+                                            this.setState({ bossTimes: currentTimes });
+                                        }
+                                    }
+                                }}
+                                bossTimes={this.state.bossTimes}
+                            />
+                        ) : null}
+                        </Clock>
                     </React.Fragment>
                     
                     


### PR DESCRIPTION
Moved the boss timer in between the timer and the controls to prevent the main time from jumping all over the screen during boss toggles.

This required a little bit more of a refactor than expected: the Clock component now has an option to render children, and the boss timer and all its buddies are passed in through props.children.

Furthermore, when removing the boss selector, the document body has to temporarily have overflow-hidden added to prevent scrolling. This may be bugged on ios mobile.