### PR TITLE
Minor 0.5.5 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4-timer",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "dependencies": {
     "firebase": "^7.3.0",

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -47,7 +47,6 @@ class BossTimer extends Component<Props, State> {
                 // user did not select a boss to assign this to, allow it to be unassigned
                 this.props.assignBoss({ id: 99, title: '???', time: this.state.currentTime });
                 this.setState({ isActive: false, finished: true }, () => {
-                    console.log(this.state, document.body.classList);
                 if(document.body) document.body.classList.remove('no-scroll');        
                 });
                 this.resetTimer();

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -76,14 +76,11 @@ class BossTimer extends Component<Props, State> {
     }
 
     resetTimer() {
-        if (document.body) document.body.classList.add('no-scroll');
         this.setState({ 
             isActive: false,
             startTime: 0,
             currentTime: 0,
             pauseTime: 0,
-        }, () => {
-            if(document.body) document.body.classList.remove('no-scroll');
         });
         
     }

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -34,21 +34,25 @@ class BossTimer extends Component<Props, State> {
         // a third event finalized the time, setting it back to finished and !isActive and resets the time
 
         if (e.key === ' ') {  
+            if (document.body) document.body.classList.add('no-scroll');
             if (!this.state.isActive && this.state.finished) {
                 this.setState({ isActive: true, finished: false });
                 this.beginTimer();
+                if(document.body) document.body.classList.remove('no-scroll');        
             } else if (this.state.isActive && !this.state.finished) {
                 this.setState({ isActive: false });
                 this.endTimer();
+                
             } else {
                 // user did not select a boss to assign this to, allow it to be unassigned
-                if (document.body) document.body.classList.add('no-scroll');
                 this.props.assignBoss({ id: 99, title: '???', time: this.state.currentTime });
                 this.setState({ isActive: false, finished: true }, () => {
-                    if(document.body) document.body.classList.remove('no-scroll');
+                    console.log(this.state, document.body.classList);
+                if(document.body) document.body.classList.remove('no-scroll');        
                 });
                 this.resetTimer();
             }
+            
         }
     }
 
@@ -72,12 +76,16 @@ class BossTimer extends Component<Props, State> {
     }
 
     resetTimer() {
+        if (document.body) document.body.classList.add('no-scroll');
         this.setState({ 
             isActive: false,
             startTime: 0,
             currentTime: 0,
             pauseTime: 0,
-        })
+        }, () => {
+            if(document.body) document.body.classList.remove('no-scroll');
+        });
+        
     }
 
     assignBoss(bossData: {id: number, title: string, time: number}) {

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -44,9 +44,8 @@ class BossTimer extends Component<Props, State> {
                 // user did not select a boss to assign this to, allow it to be unassigned
                 if (document.body) document.body.classList.add('no-scroll');
                 this.props.assignBoss({ id: 99, title: '???', time: this.state.currentTime });
-                
                 this.setState({ isActive: false, finished: true }, () => {
-                    if(document.body) document.body.classList.remove('no-scroll')
+                    if(document.body) document.body.classList.remove('no-scroll');
                 });
                 this.resetTimer();
             }

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -12,6 +12,10 @@ const FlagInputComponent = (props) => {
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
             </div>
+            <div className="flag-input-container">
+                <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer, height varies based on objectives"</p>
+            </div>
+            
         </React.Fragment>
     );
 }

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -8,7 +8,7 @@ const FlagInputComponent = (props) => {
             <div className="flag-input-container">
                 <FlagInputForm startTime={(flagObj) => props.onStartTimer(flagObj)}/>
             </div>
-            <p className="credits">v0.5.4 - Timer made by Fleury14</p>
+            <p className="credits">v0.5.5 - Timer made by Fleury14</p>
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
             </div>

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -13,7 +13,7 @@ const FlagInputComponent = (props) => {
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
             </div>
             <div className="flag-input-container">
-                <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer, height varies based on objectives"</p>
+                <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer on the left with a 20px padding on the far right side, height varies based on objectives"</p>
             </div>
             
         </React.Fragment>

--- a/src/components/objective-picker/objective-picker.js
+++ b/src/components/objective-picker/objective-picker.js
@@ -15,6 +15,9 @@ const ObjectivePicker = (props: Props) => {
     const { id, edit, done } = props;
     return (
         <div className="picker-container">
+            <div className="center-me">
+                <button className="picker-done" onClick={() => done()}>Done</button>
+            </div>
             <h2>Character</h2>
             <div className="picker-button-row">
                 {characters.map(char => {


### PR DESCRIPTION
Minor changes for 0.5.5:

- Added a second "Done" button in the objective picker, to attempt to minimize vertical scrolling when necessary
- Fixed a bug where there was a small scroll tick when storing an unattributed boss time (i.e. you just push space bar instead of clicking a boss). The solution is non-elegant, but works
- Added some instructions on the front in regarding the width of the timer to assist in cropping.
