### PR TITLE
fix(boss-time): scroll to top on boss toggle to prevent scroll lock

### DIFF
--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -40,11 +40,13 @@ class BossTimer extends Component<Props, State> {
                 this.beginTimer();
                 if(document.body) document.body.classList.remove('no-scroll');        
             } else if (this.state.isActive && !this.state.finished) {
+                window.scrollTo(0, 0);
                 this.setState({ isActive: false });
                 this.endTimer();
                 
             } else {
                 // user did not select a boss to assign this to, allow it to be unassigned
+                window.scrollTo(0, 0);
                 this.props.assignBoss({ id: 99, title: '???', time: this.state.currentTime });
                 this.setState({ isActive: false, finished: true }, () => {
                 if(document.body) document.body.classList.remove('no-scroll');        


### PR DESCRIPTION
Minor fix, didn't think it was revision worthy:

MAde sure to scrol to top on a boss timer trigger. It was possible to trap in a non scrolled area if you started editing a random objective during a boss timer. Now it forces a scroll to top on the boss timer click.