### PR TITLE
fix(boss timer): forgot to eenable scrolling on boss selector

### DIFF
--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -135,6 +135,7 @@ class BossTimer extends Component<Props, State> {
                     {isActive ? null : (
                         <BossSelector currentTime={currentTime} assignBoss={({ id, title }) => {
                             this.props.assignBoss({ id, title, time: this.state.currentTime });
+                            if (document.body) document.body.classList.remove('no-scroll');
                             this.setState({ isActive: false, finished: true });
                             this.resetTimer();
                         }}


### PR DESCRIPTION
I'm a dork.

I had re-enabled scrolling after an unassigned boss tick, and after the reset button, but not after the most common option: clicking a boss to assign to a timer. oops. 