### PR TITLE
fix(boss timer): use fedault space in the event of no LS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "v4-timer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "dependencies": {
     "firebase": "^7.3.0",

--- a/src/components/boss-timer/boss-timer.js
+++ b/src/components/boss-timer/boss-timer.js
@@ -33,7 +33,8 @@ class BossTimer extends Component<Props, State> {
         // clicking a second time stops times, stays unfinished but deactivates the timer
         // a third event finalized the time, setting it back to finished and !isActive and resets the time
         const selectedKey = localStorage.getItem('key');
-        if (e.key === selectedKey) {  
+        const targetKey = selectedKey || ' ';
+        if (e.key === targetKey) {  
             if (document.body) document.body.classList.add('no-scroll');
             if (!this.state.isActive && this.state.finished) {
                 this.setState({ isActive: true, finished: false });


### PR DESCRIPTION
Fix:
- If theres no local storage key, the boss timer defaults to space.