### PR TITLE
Minimize clicks

### DIFF
--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -11,6 +11,7 @@ const FlagInputComponent = (props) => {
             <p className="credits">v{process.env.REACT_APP_VERSION} - Timer made by Fleury14</p>
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
+                <p className="instructions">New change: When editing a random objective, clicking on one of the quests will automatically select the next random objective. If there are no subsequent random objectives, edit mode will end. You can still click on a respective objective's "Edit" button in case you make an error.</p>
             </div>
             <div className="flag-input-container">
                 <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer on the left with a 20px padding on the far right side, height varies based on objectives"</p>

--- a/src/components/objective-picker/quest-picker.js
+++ b/src/components/objective-picker/quest-picker.js
@@ -79,7 +79,7 @@ const displayMultiRow = (props:Props) => {
     });
     return (
         <div className="obj-picker-top">
-            {multiKeyObj.map(objective => {
+            {multiKeyObj.map((objective) => {
                 let iconDisplay = [];
                 objective.keyItemId.forEach(keyItem => {
                     const selectedItem = keyItems.find(eachItem => eachItem.id === keyItem);
@@ -96,11 +96,11 @@ const displayMultiRow = (props:Props) => {
                     if (selectedObj) openObjectives.push(selectedObj);
                 })
                 return (
-                    <div className="multi-key-cont">
+                    <div key={objective.objectiveSlug[0]} className="multi-key-cont">
                         <div className="multi-key-item">
                             {iconDisplay.map(item => {
                                 if (item) return (
-                                    <img src={`/images/key-item-icons/${item.iconFile}`} alt={item.title} title={item.title}/>  
+                                    <img key={item.title} src={`/images/key-item-icons/${item.iconFile}`} alt={item.title} title={item.title}/>  
                                 )
                                 return null;
                             })}

--- a/src/components/objective/objective.js
+++ b/src/components/objective/objective.js
@@ -12,7 +12,8 @@ type Props = {
     edit: Function,
     time: ?number,
     complete: ?boolean,
-    random?: boolean
+    random?: boolean,
+    editing: boolean,
 }
 
 
@@ -20,10 +21,9 @@ class Objective extends Component<Props> {
     
     render() {
         
-        const { title, id, finish, time, undo, complete, random, edit } = this.props;
-        
+        const { title, id, finish, time, undo, complete, random, edit, editing } = this.props;
         return (
-            <div className="objective-container">
+            <div className={`objective-container${editing === id ? ' objective-editing' : ''}`}>
                 <p className={complete ? "objective-title-complete" : "objective-title"}>
                     {title}
                     {random ? <button className="objective-edit-button" onClick={(id) => edit(id)}>Edit</button> : null}

--- a/src/components/objective/objective.scss
+++ b/src/components/objective/objective.scss
@@ -5,6 +5,10 @@
     min-width: 400px;
 }
 
+.objective-editing {
+    background-color: #444;
+}
+
 .objective-title {
     color: #fadf0f;
     font-size: 14px;

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -113,14 +113,35 @@ class TimerComponent extends Component<Props, State> {
     }
 
     applyEdit(id: number, title: string) {
-        const { flagObj } = this.state;
+        const { flagObj, objectiveEditing } = this.state;
         if (flagObj && flagObj.objectives) {
             const target:void | TObjective = flagObj.objectives.find(obj => obj.id === id);
             if (target) {
                 target.label = title;
             }
-            this.setState({ flagObj })
+            let newObjEditing = objectiveEditing;
+            if (typeof newObjEditing === 'number') {
+                if (newObjEditing === flagObj.objectives.length - 1) {
+                    newObjEditing = null;
+                } else {
+                    while (newObjEditing < flagObj.objectives.length - 1) {
+                        if (flagObj.objectives[newObjEditing + 1].random) {
+                            newObjEditing++;
+                            break;
+                        }
+                        if (newObjEditing === flagObj.objectives.length - 2) {
+                            newObjEditing = null;
+                            break;
+                        }
+                        newObjEditing++;
+                    }
+                }
+                
+            }
+            
+            this.setState({ flagObj, objectiveEditing: newObjEditing })
         }
+        
         
     }
 

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -180,7 +180,7 @@ class TimerComponent extends Component<Props, State> {
                                     finish={(id) => this.objectiveComplete(id)}
                                     time={objective.time}
                                     undo={(id) => this.undoObjective(id)}
-                                    editRandom={() => this.toggleRandomEditor(objective.id)}
+                                    edit={() => this.toggleRandomEditor(objective.id)}
                                 />
                             )
                             return null;

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -141,6 +141,7 @@ class TimerComponent extends Component<Props, State> {
                         {!this.state.timerActive && this.props.flagObj && this.props.flagObj.objectives.map(objective => {
                             if (!objective.time) return (
                                 <Objective
+                                    editing={this.state.objectiveEditing}
                                     key={objective.id}
                                     title={objective.label}
                                     id={objective.id}
@@ -155,6 +156,7 @@ class TimerComponent extends Component<Props, State> {
                         {this.state.timerActive && this.state.flagObj && this.state.flagObj.objectives.map(objective => {
                             if (!objective.time) return (
                                 <Objective
+                                    editing={this.state.objectiveEditing}
                                     key={objective.id}
                                     title={objective.label}
                                     id={objective.id}


### PR DESCRIPTION
This update attempts to minimize the clicks when assigning objectives to Random objectives.

- When you select an objective to edit, that objective is highlighted on the list
- Selecting an goal automatically selects the next objective on the list
- When the last random objective is selected, edit mode terminates
- The "Done" button still terminates edit mode as before.

Now, ideally, when inputting five objectives, you select the first one and you only have to click 5 times, as opposed to 10 from before.