### PR TITLE
Keyboard controls

### DIFF
--- a/src/components/color-gateway/color-gateway.js
+++ b/src/components/color-gateway/color-gateway.js
@@ -13,6 +13,9 @@ type State = {
     key: string,
     code: string,
     isInputtingKey: boolean,
+    isInputtingTimerKey: boolean,
+    timerCode: string,
+    timerKey: string,
 };
 
 class ColorGateway extends Component<Props, State> {
@@ -23,6 +26,9 @@ class ColorGateway extends Component<Props, State> {
         key: ' ',
         code: 'Space',
         isInputtingKey: false,
+        isInputtingTimerKey: false,
+        timerCode: 'KeyJ',
+        timerKey: 'j',
     }
 
     keyListener:any = null;
@@ -32,6 +38,8 @@ class ColorGateway extends Component<Props, State> {
         const savedColor: ?string = localStorage.getItem('color');
         const savedKey: ?string = localStorage.getItem('key');
         const savedCode: ?string = localStorage.getItem('code');
+        const savedTimerKey: ?string = localStorage.getItem('timerKey');
+        const savedTimerCode: ?string = localStorage.getItem('timerCode');
         const gateway = document.querySelector('.color-gateway');
         if (gateway && savedColor) {
             gateway.style.backgroundColor = savedColor;
@@ -41,6 +49,9 @@ class ColorGateway extends Component<Props, State> {
         }
         if (savedKey && savedCode) {
             this.setState({ code: savedCode, key: savedKey })
+        }
+        if (savedTimerKey && savedTimerCode) {
+            this.setState({ timerCode: savedTimerCode, timerKey: savedTimerKey });
         }
     }
 
@@ -72,6 +83,21 @@ class ColorGateway extends Component<Props, State> {
             this.setState({ key: e.key, code: e.code, isInputtingKey: false });
         }
     }
+    inputTimerKey() {
+        this.setState({
+            isInputtingTimerKey: true,   
+        }, () => {
+        this.keyListener = document.addEventListener('keyup', this.timerListenerCommands.bind(this));
+        });
+    }
+
+    timerListenerCommands(e: KeyboardEvent) {
+        if (this.state.isInputtingTimerKey) {
+            localStorage.setItem('timerKey', e.key);
+            localStorage.setItem('timerCode', e.code);
+            this.setState({ timerKey: e.key, timerCode: e.code, isInputtingTimerKey: false });
+        }
+    }
 
     render() {
         return (
@@ -99,6 +125,16 @@ class ColorGateway extends Component<Props, State> {
                             </React.Fragment>
                         ) : (
                             <button onClick={() => this.inputKey()}>Change</button>
+                        )}
+                    </div>
+                    <div className="key-changer">
+                        <p>Stop/Resume Timer Key: {this.state.timerCode}</p>
+                        {this.state.isInputtingTimerKey ? (
+                            <React.Fragment>
+                                <p className="desired-key-prompt">Press Desired Key</p>
+                            </React.Fragment>
+                        ) : (
+                            <button onClick={() => this.inputTimerKey()}>Change</button>
                         )}
                     </div>
                 </div>

--- a/src/components/flag-info/flag-badges.js
+++ b/src/components/flag-info/flag-badges.js
@@ -119,6 +119,12 @@ const renderGlitches = (flags: string) => {
     if (glitchString.indexOf('64') >= 0) {
         glitchText.push(<span key="64" className="flag-badge"> 64 Door</span>);
     }
+    if (glitchString.indexOf('sylph') < 0) {
+        glitchText.push(<span key="sylph" className="flag-badge flag-badge-danger"> Sylph gitch OFF</span>)
+    }
+    if (glitchString.indexOf('sylph') >= 0) {
+        glitchText.push(<span key="sylph" className="flag-badge"> Sylph</span>)
+    }
 
     return (<div>{glitchText}</div>);
 }

--- a/src/components/flag-info/flag-badges.js
+++ b/src/components/flag-info/flag-badges.js
@@ -224,6 +224,27 @@ const renderVanilla = (flags: string) => {
     return vanilla.length > 0 ? (<div>{vanilla}</div>) : null;
 }
 
+const renderEncounters = (flags: string) => {
+    const encounters = [];
+
+    const encounterFlagString = getPropertySection(flags, 'E');
+    
+    if (encounterFlagString.indexOf('sirens') >= 0 || encounterFlagString.indexOf('jdrops') >= 0) {
+        encounters.push(<span key="no-siren-steal" className="flag-badge">Cannot steal Sirens</span>);
+    }
+    if (encounterFlagString.indexOf('cantrun') >= 0) {
+        encounters.push(<span key="no-escape" className="flag-badge">No escape</span>);
+    }
+    if (encounterFlagString.indexOf('danger') >= 0) {
+        encounters.push(<span key="danger" className="flag-badge">Back/surprise attacks enabled</span>);
+    }
+    if (encounterFlagString.indexOf('noencounters') >= 0) {
+        encounters.push(<span key="no-encounters" className="flag-badge flag-badge-danger">No encounters</span>);
+    }
+
+    return <div>{encounters}</div>
+}
+
 const getPropertySection = (flags: string, criteria: string) => {
     // get shop section of flag string
     const begin = flags.indexOf(criteria);
@@ -240,4 +261,4 @@ const getPropertySection = (flags: string, criteria: string) => {
     return results;
 }
 
-export { renderCharacters, renderGlitches, renderKeyItems, renderMisc, renderShops, renderTreasure, renderVanilla };
+export { renderCharacters, renderGlitches, renderKeyItems, renderMisc, renderShops, renderTreasure, renderVanilla, renderEncounters };

--- a/src/components/flag-info/flag-info.js
+++ b/src/components/flag-info/flag-info.js
@@ -9,6 +9,7 @@ import {
     renderGlitches,
     renderMisc,
     renderVanilla,
+    renderEncounters,
 } from './flag-badges';
 import './flag-info.scss';
 
@@ -41,6 +42,10 @@ const FlagInfo = (props: string) => {
             <div className="flag-info-row">
                 <p className="flag-info-label">Misc:</p>
                 {renderMisc(flags)}
+            </div>
+            <div className="flag-info-row">
+                <p className="flag-info-label">Encounters:</p>
+                {renderEncounters(flags)}
             </div>
             {vanillaData ? (
                 <div className="flag-info-row">

--- a/src/components/flag-input/flag-input-form.js
+++ b/src/components/flag-input/flag-input-form.js
@@ -40,7 +40,11 @@ class FlagInputForm extends Component {
                     <button onClick={() => this.setState({ flags: 'Orandom:5/win:crystal Kmain/summon/moon Pkey Cstandard/j:abilities Tstandard Sstandard Bstandard/alt:gauntlet Nchars/key Etoggle Glife -kit:basic -noadamants' })}>Fabul Gauntlet - Swiss</button>
                     <button onClick={() => this.setState({ flags: 'Orandom:5/win:crystal Kmain/summon/moon Pkey Cstandard/distinct:7/j:abilities/nodupes/bye Tpro Spro/quarter Bstandard/alt:gauntlet Nchars/key Etoggle Glife -kit:basic -noadamants' })}>Fabul Gauntlet - Bracket</button>
                     <button onClick={() => this.setState({ flags: 'Omode:classicforge/1:quest_giant/random:2/win:crystal Kmain/summon/moon/unsafe Pkey Cstandard/distinct:7/j:abilities/nodupes Tpro Spro Bstandard Nchars/key Etoggle Glife -kit:basic -noadamants' })}>Underground Racing Club</button>
-                    <button onClick={() => this.setState({ flags: 'O1:quest_masamunealtar/2:quest_ribbonaltar/random:2/win:crystal Kmain/summon/moon/unsafe Pkey Cstandard/distinct:7/j:abilities/nodupes Tpro Spro Bstandard Nchars/key Etoggle Glife -noadamants' })}>Lunar Racing Club</button>
+                    <button onClick={() => this.setState({ flags: 'O1:quest_masamunealtar/2:quest_ribbonaltar/random:2/win:crystal Kmain/summon/moon/unsafe Pkey Cstandard/distinct:7/j:abilities/nodupes Tpro Spro Bstandard Nchars/key Etoggle Glife -noadamants' })}>Lunar Racing Club</button>                    
+                </div>
+                <div className="flag-presets">
+                    <button onClick={() => this.setState({ flags: 'O1:quest_forge/random:3,quest/req:3/win:crystal Kmain/summon/moon Pkey Crelaxed/maybe/no:fusoya/j:abilities/bye Twildish/sparse:60 Sstandard Bstandard/alt:gauntlet Nkey Etoggle/cantrun Gwarp/life/sylph -kit:basic -noadamants -spoon -vanilla:agility' })}>HTT3Z Group Stages</button>
+                    <button onClick={() => this.setState({ flags: 'O1:quest_forge/random:3,quest/req:3/win:crystal Kmain/summon/moon Pkey Cstandard/maybe/no:fusoya/j:abilities/permajoin Tpro/sparse:60 Spro Bstandard/alt:gauntlet Nkey Etoggle/cantrun/no:sirens Glife/sylph -kit:basic -noadamants -vanilla:agility' })}>HTT3Z Table Stages</button>
                 </div>
             </React.Fragment>
         )

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -11,7 +11,7 @@ const FlagInputComponent = (props) => {
             <p className="credits">v{process.env.REACT_APP_VERSION} - Timer made by Fleury14</p>
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
-                <p className="instructions">Update: Tracker will now read if there are a set amount of required objectives and notify you if an objective is not required. Clicking on completing zeromus while in this state will stop the timer. Also updated some of the flag info badges. You can also press backspace to start/stop the timer via keyboard, but this will not work if the app doesn't have focus.</p>
+                <p className="instructions">Update: Tracker will now read if there are a set amount of required objectives and notify you if an objective is not required. Clicking on completing zeromus while in this state will stop the timer. Also updated some of the flag info badges. You can also press a customizable key (default is 'j') to start/stop the timer via keyboard, but this will not work if the app doesn't have focus.</p>
             </div>
             <div className="flag-input-container">
                 <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer on the left with a 20px padding on the far right side, height varies based on objectives"</p>

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -11,7 +11,7 @@ const FlagInputComponent = (props) => {
             <p className="credits">v{process.env.REACT_APP_VERSION} - Timer made by Fleury14</p>
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
-                <p className="instructions">New change: When editing a random objective, clicking on one of the quests will automatically select the next random objective. If there are no subsequent random objectives, edit mode will end. You can still click on a respective objective's "Edit" button in case you make an error.</p>
+                <p className="instructions">Update: Tracker will now read if there are a set amount of required objectives and notify you if an objective is not required. Clicking on completing zeromus while in this state will stop the timer. Also updated some of the flag info badges.</p>
             </div>
             <div className="flag-input-container">
                 <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer on the left with a 20px padding on the far right side, height varies based on objectives"</p>

--- a/src/components/flag-input/flag-input.js
+++ b/src/components/flag-input/flag-input.js
@@ -11,7 +11,7 @@ const FlagInputComponent = (props) => {
             <p className="credits">v{process.env.REACT_APP_VERSION} - Timer made by Fleury14</p>
             <div className="flag-input-container">
                 <p className="instructions">Boss Timer: To trigger a separate boss timer, push the space bar to both start and stop the timer. You then have the option to select a boss to assign the time to, or push space again to leave it unassigned. You can click on the corresponding time to select a boss later if you so desire.</p>
-                <p className="instructions">Update: Tracker will now read if there are a set amount of required objectives and notify you if an objective is not required. Clicking on completing zeromus while in this state will stop the timer. Also updated some of the flag info badges.</p>
+                <p className="instructions">Update: Tracker will now read if there are a set amount of required objectives and notify you if an objective is not required. Clicking on completing zeromus while in this state will stop the timer. Also updated some of the flag info badges. You can also press backspace to start/stop the timer via keyboard, but this will not work if the app doesn't have focus.</p>
             </div>
             <div className="flag-input-container">
                 <p className="instructions">Horizontal dimensions for cropping: 400px width for the timer on the left with a 20px padding on the far right side, height varies based on objectives"</p>

--- a/src/components/objective/objective.js
+++ b/src/components/objective/objective.js
@@ -14,6 +14,7 @@ type Props = {
     complete: ?boolean,
     random?: boolean,
     editing: boolean,
+    notRequired: boolean,
 }
 
 
@@ -21,12 +22,13 @@ class Objective extends Component<Props> {
     
     render() {
         
-        const { title, id, finish, time, undo, complete, random, edit, editing } = this.props;
+        const { title, id, finish, time, undo, complete, random, edit, editing, notRequired } = this.props;
         return (
             <div className={`objective-container${editing === id ? ' objective-editing' : ''}`}>
                 <p className={complete ? "objective-title-complete" : "objective-title"}>
                     {title}
                     {random ? <button className="objective-edit-button" onClick={(id) => edit(id)}>Edit</button> : null}
+                    {notRequired && title.indexOf('Zeromus') < 0 ? <span>(not required)</span> : null}
                 </p>
                 {time
                     ?  <div className="objective-time-container">

--- a/src/components/objective/objective.js
+++ b/src/components/objective/objective.js
@@ -28,7 +28,7 @@ class Objective extends Component<Props> {
                 <p className={complete ? "objective-title-complete" : "objective-title"}>
                     {title}
                     {random ? <button className="objective-edit-button" onClick={(id) => edit(id)}>Edit</button> : null}
-                    {notRequired && title.indexOf('Zeromus') < 0 ? <span>&nbsp;(not required)</span> : null}
+                    {notRequired && title.indexOf('Zeromus') < 0 ? <span class="objective-not-required-badge">NOT REQUIRED</span> : null}
                 </p>
                 {time
                     ?  <div className="objective-time-container">

--- a/src/components/objective/objective.js
+++ b/src/components/objective/objective.js
@@ -24,11 +24,11 @@ class Objective extends Component<Props> {
         
         const { title, id, finish, time, undo, complete, random, edit, editing, notRequired } = this.props;
         return (
-            <div className={`objective-container${editing === id ? ' objective-editing' : ''}`}>
+            <div className={`objective-container${editing === id ? ' objective-editing' : ''}${notRequired && title.indexOf('Zeromus') < 0 ? ' objective-not-required' : ''}`}>
                 <p className={complete ? "objective-title-complete" : "objective-title"}>
                     {title}
                     {random ? <button className="objective-edit-button" onClick={(id) => edit(id)}>Edit</button> : null}
-                    {notRequired && title.indexOf('Zeromus') < 0 ? <span>(not required)</span> : null}
+                    {notRequired && title.indexOf('Zeromus') < 0 ? <span>&nbsp;(not required)</span> : null}
                 </p>
                 {time
                     ?  <div className="objective-time-container">

--- a/src/components/objective/objective.scss
+++ b/src/components/objective/objective.scss
@@ -5,6 +5,10 @@
     min-width: 400px;
 }
 
+.objective-not-required {
+    background-color: #663300;
+}
+
 .objective-editing {
     background-color: #444;
 }

--- a/src/components/objective/objective.scss
+++ b/src/components/objective/objective.scss
@@ -9,6 +9,14 @@
     background-color: #663300;
 }
 
+.objective-not-required-badge {
+    background-color: #ff9c33;
+    color: black;
+    font-size: 10px;
+    margin-left: 20px;
+    padding: 0px 3px;
+}
+
 .objective-editing {
     background-color: #444;
 }

--- a/src/components/objective/objective.scss
+++ b/src/components/objective/objective.scss
@@ -74,8 +74,6 @@
     height: 19px;
     margin-left: 10px;
     background-color: #fadf0f;
-    position: relative;
-    bottom: 2px;
     border-radius: 3px;
     border: none;
 }

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -19,7 +19,8 @@ type State = {
     flagObj: ?FlagObject,
     finished: boolean,
     objectiveEditing: ?number,
-    bossTimes: BossTime[]
+    bossTimes: BossTime[],
+    required: number,
 }
 
 class TimerComponent extends Component<Props, State> {
@@ -33,6 +34,7 @@ class TimerComponent extends Component<Props, State> {
         finished: false,
         objectiveEditing: null,
         bossTimes: [],
+        required: 0,
     }
 
     beginTimer() {

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -38,7 +38,9 @@ class TimerComponent extends Component<Props, State> {
     }
 
     onPress(e: KeyboardEvent) {
-        if(e.key === 'Backspace') {
+        const storedTimerKey = localStorage.getItem('timerKey');
+        const selectedKey = storedTimerKey || 'j';
+        if(e.key === selectedKey) {
 
             this.state.timerActive ? this.endTimer() : this.beginTimer();
         }
@@ -290,7 +292,7 @@ class TimerComponent extends Component<Props, State> {
                             />
                         ) : null}
                         </Clock>
-                        <p>Press Backspace to stop/resume timer with keyboard</p>
+                        <p>Press the key display at the top to stop/resume timer with keyboard</p>
                     </React.Fragment>
                     
                     

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -150,8 +150,12 @@ class TimerComponent extends Component<Props, State> {
     render() {
         // sort objectives by finished time for completed objectives
         let sortedObj = null;
+        let goMode = false;
         if (this.state.flagObj) {
             sortedObj = this.state.flagObj.objectives.sort((a:TObjective, b:TObjective) => a.time !== undefined && b.time !== undefined ? a.time - b.time : 0);
+            if (this.state.flagObj && this.state.flagObj.required > 0 && this.state.flagObj.objectives && this.state.flagObj.objectives.filter(obj => obj.time !== 0).length >= this.state.flagObj.required) {
+                goMode = true;
+            }
         }
         const hasFinishedOne = (this.state.flagObj && this.state.flagObj.objectives && this.state.flagObj.objectives.find(obj => obj.time !== 0));
         
@@ -164,6 +168,7 @@ class TimerComponent extends Component<Props, State> {
                         {!this.state.timerActive && this.props.flagObj && this.props.flagObj.objectives.map(objective => {
                             if (!objective.time) return (
                                 <Objective
+                                    notRequired={goMode}
                                     editing={this.state.objectiveEditing}
                                     key={objective.id}
                                     title={objective.label}
@@ -179,6 +184,7 @@ class TimerComponent extends Component<Props, State> {
                         {this.state.timerActive && this.state.flagObj && this.state.flagObj.objectives.map(objective => {
                             if (!objective.time) return (
                                 <Objective
+                                    notRequired={goMode}
                                     editing={this.state.objectiveEditing}
                                     key={objective.id}
                                     title={objective.label}

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -187,7 +187,7 @@ class TimerComponent extends Component<Props, State> {
             <div className="whole-wrapper">
                 <div className="left-wrapper">
                     <div>
-                        <h2 className="sub-title">REMAINING</h2>
+                        <h2 className="sub-title">REMAINING{this.props.flagObj && this.props.flagObj.required ? ` (COMPLETE ${this.props.flagObj.required})` : ''}</h2>
                         {/* this handles pre-start display, and avoids the need to set state upon mounting/updating */}
                         {!this.state.timerActive && this.props.flagObj && this.props.flagObj.objectives.map(objective => {
                             if (!objective.time) return (

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -37,6 +37,21 @@ class TimerComponent extends Component<Props, State> {
         required: 0,
     }
 
+    onPress(e: KeyboardEvent) {
+        if(e.key === 'Backspace') {
+
+            this.state.timerActive ? this.endTimer() : this.beginTimer();
+        }
+    }
+
+    componentDidMount() {
+        document.addEventListener('keyup', this.onPress.bind(this));
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keyup', this.onPress.bind(this));
+    }
+
     beginTimer() {
         const startDate = this.state.pauseTime === 0 ? Date.now() : Date.now() - this.state.pauseTime;
         this.interval = setInterval(() => {
@@ -53,10 +68,13 @@ class TimerComponent extends Component<Props, State> {
     }
 
     endTimer() {
-        if (this.interval) {
-            clearInterval(this.interval);
+        if (this.state.timerActive) {
+            if (this.interval) {
+                clearInterval(this.interval);
+            }
+            this.setState({ pauseTime: Date.now() - this.state.startTime, timerActive: false });
         }
-        this.setState({ pauseTime: Date.now() - this.state.startTime, timerActive: false });
+        
     }
 
     resetTimer() {
@@ -272,6 +290,7 @@ class TimerComponent extends Component<Props, State> {
                             />
                         ) : null}
                         </Clock>
+                        <p>Press Backspace to stop/resume timer with keyboard</p>
                     </React.Fragment>
                     
                     

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -171,7 +171,13 @@ class TimerComponent extends Component<Props, State> {
         let goMode = false;
         if (this.state.flagObj) {
             sortedObj = this.state.flagObj.objectives.sort((a:TObjective, b:TObjective) => a.time !== undefined && b.time !== undefined ? a.time - b.time : 0);
-            if (this.state.flagObj && this.state.flagObj.required > 0 && this.state.flagObj.objectives && this.state.flagObj.objectives.filter(obj => obj.time !== 0).length >= this.state.flagObj.required) {
+            if (
+                this.state.flagObj
+                && this.state.flagObj.required
+                && this.state.flagObj.required > 0
+                && this.state.flagObj.objectives
+                && this.state.flagObj.required <= this.state.flagObj.objectives.filter(obj => obj.time !== 0).length
+            ) {
                 goMode = true;
             }
         }

--- a/src/components/timer/timer.js
+++ b/src/components/timer/timer.js
@@ -79,8 +79,26 @@ class TimerComponent extends Component<Props, State> {
 
     checkForFinish() {
         if (this.state.flagObj) {
+            
             const unfinished:void | TObjective = this.state.flagObj.objectives.find(objective => objective.time === 0);
+            let finished:void | TObjective[] = [];
+            let zeromus = null;
+            if (this.state.flagObj && this.state.flagObj.objectives) {
+                finished = this.state.flagObj.objectives.filter(objective => objective.time !== 0)
+            }
+            if (this.state.flagObj && this.state.flagObj.objectives) {
+                zeromus = this.state.flagObj.objectives.find(obj => obj.label.indexOf('Zeromus') >= 0)
+            }
+            
+            
             if (!unfinished) {
+                this.setState({ finished: true });
+                this.endTimer();
+            } else if (
+                finished &&this.state.flagObj && this.state.flagObj.required && zeromus
+                && finished.length >= this.state.flagObj.required + 1
+                && zeromus.time !== 0
+            ) {
                 this.setState({ finished: true });
                 this.endTimer();
             }

--- a/src/data/flagSpec.js
+++ b/src/data/flagSpec.js
@@ -3,8 +3,8 @@
 const _FE_FLAGSPEC = {
     "version": [
         4,
-        0,
-        1
+        1,
+        0
     ],
     "order": [
         "Onone",
@@ -705,6 +705,20 @@ const _FE_FLAGSPEC = {
         "Orandom:3",
         "Orandom:4",
         "Orandom:5",
+        "Orandom:quest",
+        "Orandom:boss",
+        "Orandom:char",
+        "Oreq:all",
+        "Oreq:1",
+        "Oreq:2",
+        "Oreq:3",
+        "Oreq:4",
+        "Oreq:5",
+        "Oreq:6",
+        "Oreq:7",
+        "Oreq:8",
+        "Oreq:9",
+        "Oreq:10",
         "Owin:game",
         "Owin:crystal",
         "Kvanilla",
@@ -832,6 +846,7 @@ const _FE_FLAGSPEC = {
         "Gmp",
         "Gwarp",
         "Glife",
+        "Gsylph",
         "G64",
         "-kit:basic",
         "-kit:better",
@@ -839,10 +854,12 @@ const _FE_FLAGSPEC = {
         "-kit:spitball",
         "-noadamants",
         "-spoon",
+        "-exp:split",
+        "-exp:noboost",
+        "-exp:nokeybonus",
         "-vanilla:fusoya",
         "-vanilla:agility",
         "-vanilla:hobs",
-        "-vanilla:exp",
         "-vanilla:fashion",
         "-vanilla:traps",
         "-vanilla:z",
@@ -1561,6 +1578,19 @@ const _FE_FLAGSPEC = {
             "Orandom:3",
             "Orandom:4",
             "Orandom:5"
+        ],
+        [
+            "Oreq:all",
+            "Oreq:1",
+            "Oreq:2",
+            "Oreq:3",
+            "Oreq:4",
+            "Oreq:5",
+            "Oreq:6",
+            "Oreq:7",
+            "Oreq:8",
+            "Oreq:9",
+            "Oreq:10"
         ],
         [
             "Owin:game",
@@ -5832,812 +5862,914 @@ const _FE_FLAGSPEC = {
             "value": 5
         },
         {
-            "flag": "Owin:game",
+            "flag": "Orandom:quest",
             "offset": 63,
-            "size": 2,
+            "size": 1,
             "value": 1
         },
         {
-            "flag": "Owin:crystal",
-            "offset": 63,
-            "size": 2,
-            "value": 2
+            "flag": "Orandom:boss",
+            "offset": 64,
+            "size": 1,
+            "value": 1
         },
         {
-            "flag": "Kmain",
+            "flag": "Orandom:char",
             "offset": 65,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Ksummon",
+            "flag": "Oreq:all",
             "offset": 66,
-            "size": 1,
+            "size": 4,
             "value": 1
         },
         {
-            "flag": "Kmoon",
-            "offset": 67,
-            "size": 1,
-            "value": 1
+            "flag": "Oreq:1",
+            "offset": 66,
+            "size": 4,
+            "value": 2
         },
         {
-            "flag": "Ktrap",
-            "offset": 68,
-            "size": 1,
-            "value": 1
+            "flag": "Oreq:2",
+            "offset": 66,
+            "size": 4,
+            "value": 3
         },
         {
-            "flag": "Kunsafe",
-            "offset": 69,
-            "size": 1,
-            "value": 1
+            "flag": "Oreq:3",
+            "offset": 66,
+            "size": 4,
+            "value": 4
         },
         {
-            "flag": "Pshop",
+            "flag": "Oreq:4",
+            "offset": 66,
+            "size": 4,
+            "value": 5
+        },
+        {
+            "flag": "Oreq:5",
+            "offset": 66,
+            "size": 4,
+            "value": 6
+        },
+        {
+            "flag": "Oreq:6",
+            "offset": 66,
+            "size": 4,
+            "value": 7
+        },
+        {
+            "flag": "Oreq:7",
+            "offset": 66,
+            "size": 4,
+            "value": 8
+        },
+        {
+            "flag": "Oreq:8",
+            "offset": 66,
+            "size": 4,
+            "value": 9
+        },
+        {
+            "flag": "Oreq:9",
+            "offset": 66,
+            "size": 4,
+            "value": 10
+        },
+        {
+            "flag": "Oreq:10",
+            "offset": 66,
+            "size": 4,
+            "value": 11
+        },
+        {
+            "flag": "Owin:game",
             "offset": 70,
-            "size": 1,
+            "size": 2,
             "value": 1
         },
         {
-            "flag": "Pkey",
-            "offset": 71,
-            "size": 1,
-            "value": 1
+            "flag": "Owin:crystal",
+            "offset": 70,
+            "size": 2,
+            "value": 2
         },
         {
-            "flag": "Pchests",
+            "flag": "Kmain",
             "offset": 72,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cstandard",
+            "flag": "Ksummon",
             "offset": 73,
-            "size": 2,
+            "size": 1,
             "value": 1
         },
         {
-            "flag": "Crelaxed",
-            "offset": 73,
-            "size": 2,
-            "value": 2
+            "flag": "Kmoon",
+            "offset": 74,
+            "size": 1,
+            "value": 1
         },
         {
-            "flag": "Cmaybe",
+            "flag": "Ktrap",
             "offset": 75,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cdistinct:1",
+            "flag": "Kunsafe",
             "offset": 76,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Pshop",
+            "offset": 77,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Pkey",
+            "offset": 78,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Pchests",
+            "offset": 79,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cstandard",
+            "offset": 80,
+            "size": 2,
+            "value": 1
+        },
+        {
+            "flag": "Crelaxed",
+            "offset": 80,
+            "size": 2,
+            "value": 2
+        },
+        {
+            "flag": "Cmaybe",
+            "offset": 82,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cdistinct:1",
+            "offset": 83,
             "size": 4,
             "value": 1
         },
         {
             "flag": "Cdistinct:2",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 2
         },
         {
             "flag": "Cdistinct:3",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 3
         },
         {
             "flag": "Cdistinct:4",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 4
         },
         {
             "flag": "Cdistinct:5",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 5
         },
         {
             "flag": "Cdistinct:6",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 6
         },
         {
             "flag": "Cdistinct:7",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 7
         },
         {
             "flag": "Cdistinct:8",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 8
         },
         {
             "flag": "Cdistinct:9",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 9
         },
         {
             "flag": "Cdistinct:10",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 10
         },
         {
             "flag": "Cdistinct:11",
-            "offset": 76,
+            "offset": 83,
             "size": 4,
             "value": 11
         },
         {
             "flag": "Cstart:cecil",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 1
         },
         {
             "flag": "Cstart:kain",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 2
         },
         {
             "flag": "Cstart:rydia",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 3
         },
         {
             "flag": "Cstart:tellah",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 4
         },
         {
             "flag": "Cstart:edward",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 5
         },
         {
             "flag": "Cstart:rosa",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 6
         },
         {
             "flag": "Cstart:yang",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 7
         },
         {
             "flag": "Cstart:palom",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 8
         },
         {
             "flag": "Cstart:porom",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 9
         },
         {
             "flag": "Cstart:cid",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 10
         },
         {
             "flag": "Cstart:edge",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 11
         },
         {
             "flag": "Cstart:fusoya",
-            "offset": 80,
+            "offset": 87,
             "size": 4,
             "value": 12
         },
         {
             "flag": "Conly:cecil",
-            "offset": 84,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:kain",
-            "offset": 85,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:rydia",
-            "offset": 86,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:tellah",
-            "offset": 87,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:edward",
-            "offset": 88,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:rosa",
-            "offset": 89,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:yang",
-            "offset": 90,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Conly:palom",
             "offset": 91,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Conly:porom",
+            "flag": "Conly:kain",
             "offset": 92,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Conly:cid",
+            "flag": "Conly:rydia",
             "offset": 93,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Conly:edge",
+            "flag": "Conly:tellah",
             "offset": 94,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Conly:fusoya",
+            "flag": "Conly:edward",
             "offset": 95,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:cecil",
+            "flag": "Conly:rosa",
             "offset": 96,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:kain",
+            "flag": "Conly:yang",
             "offset": 97,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:rydia",
+            "flag": "Conly:palom",
             "offset": 98,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:tellah",
+            "flag": "Conly:porom",
             "offset": 99,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:edward",
+            "flag": "Conly:cid",
             "offset": 100,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:rosa",
+            "flag": "Conly:edge",
             "offset": 101,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:yang",
+            "flag": "Conly:fusoya",
             "offset": 102,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:palom",
+            "flag": "Cno:cecil",
             "offset": 103,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:porom",
+            "flag": "Cno:kain",
             "offset": 104,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:cid",
+            "flag": "Cno:rydia",
             "offset": 105,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:edge",
+            "flag": "Cno:tellah",
             "offset": 106,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cno:fusoya",
+            "flag": "Cno:edward",
             "offset": 107,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cj:spells",
+            "flag": "Cno:rosa",
             "offset": 108,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cj:abilities",
+            "flag": "Cno:yang",
             "offset": 109,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cnodupes",
+            "flag": "Cno:palom",
             "offset": 110,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cbye",
+            "flag": "Cno:porom",
             "offset": 111,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cpermajoin",
+            "flag": "Cno:cid",
             "offset": 112,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Cpermadeath",
+            "flag": "Cno:edge",
             "offset": 113,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cno:fusoya",
+            "offset": 114,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cj:spells",
+            "offset": 115,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cj:abilities",
+            "offset": 116,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cnodupes",
+            "offset": 117,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cbye",
+            "offset": 118,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cpermajoin",
+            "offset": 119,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Cpermadeath",
+            "offset": 120,
             "size": 2,
             "value": 1
         },
         {
             "flag": "Cpermadeader",
-            "offset": 113,
+            "offset": 120,
             "size": 2,
             "value": 2
         },
         {
             "flag": "Tshuffle",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 1
         },
         {
             "flag": "Tstandard",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 2
         },
         {
             "flag": "Tpro",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 3
         },
         {
             "flag": "Twild",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 4
         },
         {
             "flag": "Twildish",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 5
         },
         {
             "flag": "Tempty",
-            "offset": 115,
+            "offset": 122,
             "size": 3,
             "value": 6
         },
         {
             "flag": "Tsparse:10",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 1
         },
         {
             "flag": "Tsparse:20",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 2
         },
         {
             "flag": "Tsparse:30",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 3
         },
         {
             "flag": "Tsparse:40",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 4
         },
         {
             "flag": "Tsparse:50",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 5
         },
         {
             "flag": "Tsparse:60",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 6
         },
         {
             "flag": "Tsparse:70",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 7
         },
         {
             "flag": "Tsparse:80",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 8
         },
         {
             "flag": "Tsparse:90",
-            "offset": 118,
+            "offset": 125,
             "size": 4,
             "value": 9
         },
         {
             "flag": "Tno:j",
-            "offset": 122,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Tjunk",
-            "offset": 123,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Sshuffle",
-            "offset": 124,
-            "size": 3,
-            "value": 1
-        },
-        {
-            "flag": "Sstandard",
-            "offset": 124,
-            "size": 3,
-            "value": 2
-        },
-        {
-            "flag": "Spro",
-            "offset": 124,
-            "size": 3,
-            "value": 3
-        },
-        {
-            "flag": "Swild",
-            "offset": 124,
-            "size": 3,
-            "value": 4
-        },
-        {
-            "flag": "Scabins",
-            "offset": 124,
-            "size": 3,
-            "value": 5
-        },
-        {
-            "flag": "Sempty",
-            "offset": 124,
-            "size": 3,
-            "value": 6
-        },
-        {
-            "flag": "Sfree",
-            "offset": 127,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Squarter",
-            "offset": 128,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Sno:j",
             "offset": 129,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Sno:apples",
+            "flag": "Tjunk",
             "offset": 130,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Sno:sirens",
+            "flag": "Sshuffle",
             "offset": 131,
-            "size": 1,
+            "size": 3,
             "value": 1
         },
         {
-            "flag": "Sunsafe",
-            "offset": 132,
-            "size": 1,
-            "value": 1
+            "flag": "Sstandard",
+            "offset": 131,
+            "size": 3,
+            "value": 2
         },
         {
-            "flag": "Bstandard",
-            "offset": 133,
-            "size": 1,
-            "value": 1
+            "flag": "Spro",
+            "offset": 131,
+            "size": 3,
+            "value": 3
         },
         {
-            "flag": "Bunsafe",
+            "flag": "Swild",
+            "offset": 131,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "Scabins",
+            "offset": 131,
+            "size": 3,
+            "value": 5
+        },
+        {
+            "flag": "Sempty",
+            "offset": 131,
+            "size": 3,
+            "value": 6
+        },
+        {
+            "flag": "Sfree",
             "offset": 134,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Balt:gauntlet",
+            "flag": "Squarter",
             "offset": 135,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Bwhyburn",
+            "flag": "Sno:j",
             "offset": 136,
-            "size": 2,
+            "size": 1,
             "value": 1
         },
         {
-            "flag": "Bwhichburn",
-            "offset": 136,
-            "size": 2,
-            "value": 2
+            "flag": "Sno:apples",
+            "offset": 137,
+            "size": 1,
+            "value": 1
         },
         {
-            "flag": "Nchars",
+            "flag": "Sno:sirens",
             "offset": 138,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Nkey",
+            "flag": "Sunsafe",
             "offset": 139,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Nbosses",
+            "flag": "Bstandard",
             "offset": 140,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Etoggle",
+            "flag": "Bunsafe",
             "offset": 141,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Balt:gauntlet",
+            "offset": 142,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "Bwhyburn",
+            "offset": 143,
             "size": 2,
             "value": 1
         },
         {
-            "flag": "Ereduce",
-            "offset": 141,
+            "flag": "Bwhichburn",
+            "offset": 143,
             "size": 2,
             "value": 2
         },
         {
-            "flag": "Enoencounters",
-            "offset": 141,
-            "size": 2,
-            "value": 3
-        },
-        {
-            "flag": "Ekeep:doors",
-            "offset": 143,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Ekeep:behemoths",
-            "offset": 144,
-            "size": 1,
-            "value": 1
-        },
-        {
-            "flag": "Edanger",
+            "flag": "Nchars",
             "offset": 145,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Ecantrun",
+            "flag": "Nkey",
             "offset": 146,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Enoexp",
+            "flag": "Nbosses",
             "offset": 147,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Eno:jdrops",
+            "flag": "Etoggle",
             "offset": 148,
             "size": 2,
             "value": 1
         },
         {
-            "flag": "Eno:sirens",
+            "flag": "Ereduce",
             "offset": 148,
             "size": 2,
             "value": 2
         },
         {
-            "flag": "Gdupe",
+            "flag": "Enoencounters",
+            "offset": 148,
+            "size": 2,
+            "value": 3
+        },
+        {
+            "flag": "Ekeep:doors",
             "offset": 150,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Gmp",
+            "flag": "Ekeep:behemoths",
             "offset": 151,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Gwarp",
+            "flag": "Edanger",
             "offset": 152,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "Glife",
+            "flag": "Ecantrun",
             "offset": 153,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "G64",
+            "flag": "Enoexp",
             "offset": 154,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-kit:basic",
+            "flag": "Eno:jdrops",
             "offset": 155,
-            "size": 3,
+            "size": 2,
             "value": 1
         },
         {
-            "flag": "-kit:better",
+            "flag": "Eno:sirens",
             "offset": 155,
-            "size": 3,
+            "size": 2,
             "value": 2
         },
         {
-            "flag": "-kit:loaded",
-            "offset": 155,
-            "size": 3,
-            "value": 3
+            "flag": "Gdupe",
+            "offset": 157,
+            "size": 1,
+            "value": 1
         },
         {
-            "flag": "-kit:spitball",
-            "offset": 155,
-            "size": 3,
-            "value": 4
-        },
-        {
-            "flag": "-noadamants",
+            "flag": "Gmp",
             "offset": 158,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-spoon",
+            "flag": "Gwarp",
             "offset": 159,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-vanilla:fusoya",
+            "flag": "Glife",
             "offset": 160,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-vanilla:agility",
+            "flag": "Gsylph",
             "offset": 161,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-vanilla:hobs",
+            "flag": "G64",
             "offset": 162,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-vanilla:exp",
+            "flag": "-kit:basic",
             "offset": 163,
-            "size": 1,
+            "size": 3,
             "value": 1
         },
         {
-            "flag": "-vanilla:fashion",
-            "offset": 164,
-            "size": 1,
-            "value": 1
+            "flag": "-kit:better",
+            "offset": 163,
+            "size": 3,
+            "value": 2
         },
         {
-            "flag": "-vanilla:traps",
-            "offset": 165,
-            "size": 1,
-            "value": 1
+            "flag": "-kit:loaded",
+            "offset": 163,
+            "size": 3,
+            "value": 3
         },
         {
-            "flag": "-vanilla:z",
+            "flag": "-kit:spitball",
+            "offset": 163,
+            "size": 3,
+            "value": 4
+        },
+        {
+            "flag": "-noadamants",
             "offset": 166,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-vintage",
+            "flag": "-spoon",
             "offset": 167,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-pushbtojump",
+            "flag": "-exp:split",
             "offset": 168,
             "size": 1,
             "value": 1
         },
         {
-            "flag": "-spoiler",
+            "flag": "-exp:noboost",
             "offset": 169,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-exp:nokeybonus",
+            "offset": 170,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:fusoya",
+            "offset": 171,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:agility",
+            "offset": 172,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:hobs",
+            "offset": 173,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:fashion",
+            "offset": 174,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:traps",
+            "offset": 175,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vanilla:z",
+            "offset": 176,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-vintage",
+            "offset": 177,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-pushbtojump",
+            "offset": 178,
+            "size": 1,
+            "value": 1
+        },
+        {
+            "flag": "-spoiler",
+            "offset": 179,
             "size": 1,
             "value": 1
         }
@@ -7343,7 +7475,10 @@ const _FE_FLAGSPEC = {
                 "Orandom:2",
                 "Orandom:3",
                 "Orandom:4",
-                "Orandom:5"
+                "Orandom:5",
+                "Orandom:quest",
+                "Orandom:boss",
+                "Orandom:char"
             ]
         ],
         "Kvanilla": [
@@ -7472,6 +7607,7 @@ const _FE_FLAGSPEC = {
                 "Gmp",
                 "Gwarp",
                 "Glife",
+                "Gsylph",
                 "G64"
             ]
         ]
@@ -7934,8 +8070,12 @@ class FlagLogicCore {
             this._simple_disable(flagset, log, "Encounters are vanilla", ["Ekeep:behemoths", "Ekeep:doors", "Edanger"]);
         }
         if (flagset.has("Onone")) {
-            this._simple_disable_regex(flagset, log, "No objectives set", "^Owin:");
+            this._simple_disable_regex(flagset, log, "No objectives set", "^O(win|req):");
         } else {
+            if ((! flagset.get_list("^Oreq:"))) {
+                flagset.set("Oreq:all");
+                this._lib.push(log, ["correction", "Required number of objectives not specified; setting Oreq:all"]);
+            }
             win_flags = flagset.get_list("^Owin:");
             if ((flagset.has("Omode:classicforge") && (! flagset.has("Owin:crystal")))) {
                 flagset.set("Owin:crystal");
@@ -8005,6 +8145,9 @@ class FlagLogicCore {
                         }
                     }
                 }
+            }
+            if ((! flagset.get_list("^Orandom:\\d"))) {
+                this._simple_disable_regex(flagset, log, "No random objectives specified", "^Orandom:[^\\d]");
             }
         }
         return log;

--- a/src/helpers/parse-flags.js
+++ b/src/helpers/parse-flags.js
@@ -10,6 +10,7 @@ const parseFlags = (flagString: string) => {
 
     const flagObj:FlagObject = {
         objectives: [],
+        required: 0,
     }
     // check set objectives (non-custom)
     if (flagString.indexOf('dkmatter') >= 0 ) {
@@ -105,6 +106,11 @@ const parseFlags = (flagString: string) => {
             label: 'Defeat Zeromus',
             time: 0,
         })
+    }
+
+    // required objective number
+    if (flagString.indexOf('req:') >= 0) {
+        flagObj.required = parseInt(flagString.charAt(flagString.indexOf('req:') + 4));
     }
 
     return flagObj;

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -8,7 +8,8 @@ export type TObjective = {
 };
 
 export type FlagObject = {
-    objectives: TObjective[]
+    objectives: TObjective[],
+    required: number
 }
 
 export type Quest = {


### PR DESCRIPTION
Updates for the 4.1 FE release
- Added support for require set number of objectives, when the requirement has been met, remaining non Zeroums objectives are tagged as not required. Completing Zeromus in this state stops the timer.
- Added support for starting/stopping via customizable keyboard press.
- Added the Slyph flag to displayed glitches, also added encounter warnings

These changes have been live for 5 days with heavy use and no issue.
